### PR TITLE
bugfix/17 Define download_url in jboss::params and load it to init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,7 +70,7 @@ class jboss (
   $jboss_user       = $jboss::params::jboss_user,
   $jboss_group      = $jboss::params::jboss_group,
   $version          = $jboss::params::version,
-  $download_url     = "${jboss::params::download_urlbase}/${product}/${version}/${product}-${version}.zip",
+  $download_url     = $jboss::params::download_url,
   $java_autoinstall = $jboss::params::java_autoinstall,
   $java_version     = $jboss::params::java_version,
   $java_package     = $jboss::params::java_package,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,8 +22,11 @@ class jboss::params inherits jboss::internal::params {
   # Group for Jboss Application Server
   $jboss_group      = hiera('jboss::params::jboss_group', 'jboss')
 
-  # Download URL for Jboss Application Server installation package
+  # Base URL for downloading Jboss Application Server installation package
   $download_urlbase = hiera('jboss::params::download_urlbase', 'http://download.jboss.org')
+
+  # Full URL for downloading JBoss Application Server installation package
+  $download_url     = hiera('jboss::params::download_url', "${download_urlbase}/${product}/${version}/${product}-${version}.zip")
 
   # Target installation directory root
   $install_dir      = hiera('jboss::params::install_dir', '/usr/lib')

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,7 +16,7 @@ describe 'jboss', :type => :class do
       is_expected.to contain_class('jboss').with({
         :product      => 'wildfly',
         :version      => '8.2.0.Final',
-        :download_url => 'http://example.com/wildfly/8.2.0.Final/wildfly-8.2.0.Final.zip'
+        :download_url => 'http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.zip'
         })
     end
     it { is_expected.to contain_anchor 'jboss::begin' }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -12,7 +12,13 @@ describe 'jboss', :type => :class do
   end
   context 'with defaults for all parameters' do
     it { is_expected.to compile }
-    it { is_expected.to contain_class 'jboss' }
+    it do
+      is_expected.to contain_class('jboss').with({
+        :product      => 'wildfly',
+        :version      => '8.2.0.Final',
+        :download_url => 'http://example.com/wildfly/8.2.0.Final/wildfly-8.2.0.Final.zip'
+        })
+    end
     it { is_expected.to contain_anchor 'jboss::begin' }
     it { is_expected.to contain_anchor 'jboss::end' }
     it { is_expected.to contain_anchor 'jboss::configuration::begin' }
@@ -45,5 +51,16 @@ describe 'jboss', :type => :class do
     it { is_expected.to contain_class 'jboss' }
     it { is_expected.to contain_user 'appserver' }
     it { is_expected.to contain_group 'jboss' }
+  end
+  context 'with download_url => file:///tmp/wildfly-8.2.0.Final.zip set' do
+    let(:params) do
+      { :download_url => 'file:///tmp/wildfly-8.2.0.Final.zip' }
+    end
+
+    it do
+      is_expected.to contain_class('jboss').with({
+        :download_url => 'file:///tmp/wildfly-8.2.0.Final.zip'
+        })
+    end
   end
 end


### PR DESCRIPTION
Bugfix for #17. Allows users to define local path for JBoss/Wildfly installation package, ie. `jboss::params::download_url: 'file:///tmp/wildfly-8.2.0.Final.zip'`.
