### PR TITLE
Fixing #34: running acceptance tests on rvm 2.1 instead of default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,20 +24,20 @@ matrix:
     env: PUPPET_VERSION="~> 3.0"
   - rvm: '2.1'
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES=yes
-  - rvm: default
+  - rvm: '2.1'
     sudo: required
     services: docker
-    env: PUPPET_VERSION="3.8.3" RS_SET="centos-6-x86_64-docker"
+    env: PUPPET_VERSION="3.8.4" RS_SET="centos-6-x86_64-docker"
     script: bundle exec rake acceptance
-  - rvm: default
+  - rvm: '2.1'
     sudo: required
     services: docker
-    env: PUPPET_VERSION="3.8.3" RS_SET="debian-7-x86_64-docker"
+    env: PUPPET_VERSION="3.8.4" RS_SET="debian-7-x86_64-docker"
     script: bundle exec rake acceptance
-  - rvm: default
+  - rvm: '2.1'
     sudo: required
     services: docker
-    env: PUPPET_VERSION="3.8.3" RS_SET="ubuntu-14.04-x86_64-docker"
+    env: PUPPET_VERSION="3.8.4" RS_SET="ubuntu-14.04-x86_64-docker"
     script: bundle exec rake acceptance
   # FIXME: GH Issue #3 - Activate acceptance tests on Travis CI for Puppet Enterprise, at least 2.8.8 and 3.8.2
 notifications:


### PR DESCRIPTION
This is blocker. Must be fixed as first