### PR TITLE
Enhancement #4: Execute standard ruby spec tests on container infrastructure of Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 addons:
   apt:
     sources:
-    - ppa:raphink/augeas
+    - augeas
     packages:
     - libaugeas-dev
     - libxml2-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 ---
 language: ruby
-# TODO: GH Issue #4 - Try to execute standard Ruby builds on Travis CI on container infrastructure
-sudo: required
-install:
-  - sudo add-apt-repository -y ppa:raphink/augeas
-  - sudo apt-get update
-  - sudo apt-get install -y libaugeas-dev libxml2-dev
-  - bundle install --without development --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+sudo: false
+addons:
+  apt:
+    sources:
+    - ppa:raphink/augeas
+    packages:
+    - libaugeas-dev
+    - libxml2-dev
+bundler_args: --without development --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+cache: bundler
 script: bundle exec rake test
 before_install: rm -f Gemfile.lock
 matrix:


### PR DESCRIPTION
This PR enhances build system on Travis CI making it use a container infrastructure for standard ruby rspec tests. That brings greater speed of boot-up and caching of bundler dependencies.

This is described in greater detail in issue #4

Nice!