### PR TITLE
Bugfix for issue #9 - Correct way options parameter is validated and displayed

### DIFF
--- a/lib/puppet/provider/jboss_datasource/jbosscli.rb
+++ b/lib/puppet/provider/jboss_datasource/jbosscli.rb
@@ -206,10 +206,25 @@ Puppet::Type.type(:jboss_datasource).provide(:jbosscli, :parent => Puppet::Provi
   end
   
   def options= value
+    actual = {}
+    absentlike = [:absent, :undef, nil]
     managed_fetched_options.each do |key, fetched_value|
-      expected_value = value[key]
-      setattrib(key, expected_value) if expected_value != fetched_value
+      actual[key] = fetched_value
+      if absentlike.include?(value)
+        expected_value = nil
+      else
+        expected_value = value[key]
+      end
+      if expected_value != fetched_value
+        setattrib(key, expected_value)
+        if expected_value.nil?
+          actual.delete(key)
+        else
+          actual[key] = expected_value
+        end
+      end
     end
+    actual
   end
   
   def enabled

--- a/lib/puppet/provider/jboss_datasource/jbosscli.rb
+++ b/lib/puppet/provider/jboss_datasource/jbosscli.rb
@@ -206,10 +206,8 @@ Puppet::Type.type(:jboss_datasource).provide(:jbosscli, :parent => Puppet::Provi
   end
   
   def options= value
-    actual = {}
     absentlike = [:absent, :undef, nil]
     managed_fetched_options.each do |key, fetched_value|
-      actual[key] = fetched_value
       if absentlike.include?(value)
         expected_value = nil
       else
@@ -217,14 +215,8 @@ Puppet::Type.type(:jboss_datasource).provide(:jbosscli, :parent => Puppet::Provi
       end
       if expected_value != fetched_value
         setattrib(key, expected_value)
-        if expected_value.nil?
-          actual.delete(key)
-        else
-          actual[key] = expected_value
-        end
       end
     end
-    actual
   end
   
   def enabled

--- a/lib/puppet/type/jboss_datasource.rb
+++ b/lib/puppet/type/jboss_datasource.rb
@@ -6,7 +6,7 @@ Puppet::Type.newtype(:jboss_datasource) do
     desc "Name of type resource"
     isnamevar
   end
-
+  
   newproperty(:xa) do
     desc "Is it XA Datasource?"
     newvalues :true, :false
@@ -15,15 +15,15 @@ Puppet::Type.newtype(:jboss_datasource) do
       value == :true or value == true
     end
   end
-
+  
   newproperty(:dbname) do
     desc "The database's name"
   end
-
+  
   newproperty(:jndiname) do
     desc "jndi-name"
   end
-
+  
   newproperty(:jta) do
     desc "jta"
     newvalues :true, :false
@@ -67,7 +67,7 @@ Puppet::Type.newtype(:jboss_datasource) do
 
   newproperty(:options) do
     desc "Extra options for datasource or xa-datasource"
-
+    
     validate do |value|
       absentlike = [:absent, :undef, nil]
       absentlike.concat(absentlike.map {|v| v.to_s})
@@ -103,7 +103,7 @@ Puppet::Type.newtype(:jboss_datasource) do
       changes.join ', '
     end
   end
-
+  
   newproperty(:enabled) do
     desc "Is datasource enabled?"
     newvalues :true, :false
@@ -124,7 +124,7 @@ Puppet::Type.newtype(:jboss_datasource) do
       end
     end
   end
-
+  
   newproperty(:port) do
     desc "port to connect"
     isrequired
@@ -132,12 +132,12 @@ Puppet::Type.newtype(:jboss_datasource) do
       unless value == '' or /^\d+$/.match(value.to_s)
         raise ArgumentError, "Datasource port is invalid, given #{value.inspect}"
       end
-    end
+    end    
     munge do |value|
-      if value == '' then 0 else Integer(value) end
+      if value == '' then 0 else Integer(value) end      
     end
   end
-
+  
   newproperty(:jdbcscheme) do
     desc "jdbcscheme to be used"
     isrequired
@@ -152,7 +152,7 @@ Puppet::Type.newtype(:jboss_datasource) do
     desc "Indicate that server is in domain mode"
     defaultto true
   end
-
+  
   newparam(:controller) do
     desc "Domain controller host:port address"
     # Default is set to support listing of datasources without parameters (for easy use)
@@ -163,7 +163,7 @@ Puppet::Type.newtype(:jboss_datasource) do
       end
     end
   end
-
+  
   newparam :ctrluser do
     desc 'A user name to connect to controller'
   end
@@ -183,3 +183,4 @@ Puppet::Type.newtype(:jboss_datasource) do
   end
 
 end
+

--- a/spec/unit/types/jboss_datasource_spec.rb
+++ b/spec/unit/types/jboss_datasource_spec.rb
@@ -18,7 +18,7 @@ describe 'jboss_datasource', :type => :type do
     context 'given :undef' do
       let(:params) { extend_params({ :controller => :undef }) }
       it do
-        expect { type }.to raise_error(ex_class, 
+        expect { type }.to raise_error(ex_class,
           'Parameter controller failed on Jboss_datasource[spec-datasource]: Domain controller must be provided')
       end
     end
@@ -28,7 +28,7 @@ describe 'jboss_datasource', :type => :type do
     context 'given invalid text' do
       let(:params) { extend_params({ :port => "an invalid port" }) }
       it do
-        expect { type }.to raise_error(ex_class, 
+        expect { type }.to raise_error(ex_class,
           'Parameter port failed on Jboss_datasource[spec-datasource]: Datasource port is invalid, given "an invalid port"')
       end
     end
@@ -56,7 +56,7 @@ describe 'jboss_datasource', :type => :type do
     context 'given invalid text " "' do
       let(:params) { extend_params({ :host => ' ' }) }
       it do
-        expect { type }.to raise_error(ex_class, 
+        expect { type }.to raise_error(ex_class,
           'Parameter host failed on Jboss_datasource[spec-datasource]: Datasource host is invalid, given " "')
       end
     end
@@ -146,31 +146,26 @@ describe 'jboss_datasource', :type => :type do
       })
     end
     context 'given invalid text' do
-      before { skip('FIXME: String should not be accepted as a parameter, ref: coi-gov-pl/puppet-jboss#9')}
       let(:options) { "an invalid text" }
       it do
         expect { type }.to raise_error(ex_class,
-          'Parameter options failed on Jboss_datasource[spec-datasource]: You can pass only hash-like objects')
+          'Parameter options failed on Jboss_datasource[spec-datasource]: You can pass only hash-like objects or absent and undef values, given "an invalid text"')
       end
     end
     context 'given invalid boolean' do
       let(:options) { true }
       it do
         expect { type }.to raise_error(ex_class,
-          'Parameter options failed on Jboss_datasource[spec-datasource]: You can pass only hash-like objects')
+          'Parameter options failed on Jboss_datasource[spec-datasource]: You can pass only hash-like objects or absent and undef values, given true')
       end
     end
     context 'given' do
       let(:options) { {} }
       subject { type.property(:options).change_to_s(from, to) }
       context 'from :absent and to hash', :from => :absent, :to => { 'alice' => 'five', 'bob' => 'seven' } do
-        before do
-          msg = 'FIXME: Handle :symbols as parameters in change_to_s, ref: coi-gov-pl/puppet-jboss#9'
-          skip(msg) if RUBY_VERSION < '1.9.0'
-        end
         let(:from) { |expl| expl.metadata[:from] }
         let(:to) { |expl| expl.metadata[:to] }
-        it { expect(subject).to eq("option 'alice' has changed from nil to \"five\", option 'bob' has changed from nil to \"seven\"") }
+        it { expect(subject).to eq("option 'alice' has been set to \"five\", option 'bob' has been set to \"seven\"") }
       end
       context 'from hash and to changed hash', :from => { 'alice' => 'five', 'bob' => 'nine' }, :to => { 'alice' => 'five', 'bob' => 'seven' } do
         let(:from) { |expl| expl.metadata[:from] }
@@ -178,10 +173,9 @@ describe 'jboss_datasource', :type => :type do
         it { expect(subject).to eq("option 'bob' has changed from \"nine\" to \"seven\"") }
       end
       context 'from hash and to :absent', :from => { 'alice' => 'five', 'bob' => 'nine' }, :to => :absent do
-        before { skip('FIXME: A proper message while executing change_to_s for :to == :absent, ref: coi-gov-pl/puppet-jboss#9')}
         let(:from) { |expl| expl.metadata[:from] }
         let(:to) { |expl| expl.metadata[:to] }
-        it { expect(subject).to eq('options has been removed') }
+        it { expect(subject).to eq('option \'alice\' was "five" and has been removed, option \'bob\' was "nine" and has been removed') }
       end
     end
   end


### PR DESCRIPTION
Changes:

 * Correct way options parameter is validated and displayed for `datasource` type
 * Fixes for handling those changes in backing provider `jboss_datasource/jbosscli`
 * Changes to rspec tests
