### PR TITLE
Bugfix for #44: Remove spaces in rspec test files before arguments

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -31,7 +31,7 @@ describe 'jboss', :type => :class do
     it { is_expected.to contain_anchor 'jboss::service::started' }
     it { is_expected.to contain_user 'jboss' }
     it { is_expected.to contain_group 'jboss' }
-    it { is_expected.to contain_class('jboss::internal::package').with ({
+    it { is_expected.to contain_class('jboss::internal::package').with({
       :version      => '8.2.0.Final',
       :product      => 'wildfly',
       :jboss_user   => 'jboss',

--- a/spec/classes/internal/configure/interfaces_spec.rb
+++ b/spec/classes/internal/configure/interfaces_spec.rb
@@ -21,21 +21,21 @@ describe 'jboss::internal::configure::interfaces', :type => :define do
     it { is_expected.to contain_class 'jboss::params' }
     it { is_expected.to contain_class 'jboss::internal::runtime::dc' }
     it { is_expected.to contain_class 'jboss::internal::configure::interfaces' }
-    it { is_expected.to contain_jboss__interface('public').with ({
+    it { is_expected.to contain_jboss__interface('public').with({
       :ensure       => 'present',
       :inet_address => nil
       }) }
-    it { is_expected.to contain_augeas('ensure present interface public').with ({
+    it { is_expected.to contain_augeas('ensure present interface public').with({
         :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
         :changes => "set server/interfaces/interface[last()+1]/#attribute/name public",
         :onlyif  => "match server/interfaces/interface[#attribute/name='public'] size == 0"
         }) }
-    it { is_expected.to contain_augeas('interface public set any-address').with ({
+    it { is_expected.to contain_augeas('interface public set any-address').with({
       :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
       :changes => "set server/interfaces/interface[#attribute/name='public']/any-address/#attribute/value 'true'",
       :onlyif  => "get server/interfaces/interface[#attribute/name='public']/any-address/#attribute/value != 'true'"
       }) }
-    it { is_expected.to contain_jboss__internal__interface__foreach("public:any-address").with ({
+    it { is_expected.to contain_jboss__internal__interface__foreach("public:any-address").with({
       :cfg_file => '/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml',
       :path     => 'server/interfaces'
       }) }
@@ -44,17 +44,17 @@ describe 'jboss::internal::configure::interfaces', :type => :define do
       it { is_expected.to contain_anchor("#{item}") }
     end
     bind_variables_list.each do |var|
-      it { is_expected.to contain_augeas("interface public rm #{var}").with ({
+      it { is_expected.to contain_augeas("interface public rm #{var}").with({
         :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
         :changes => "rm server/interfaces/interface[#attribute/name='public']/#{var}",
         :onlyif  => "match server/interfaces/interface[#attribute/name='public']/#{var} size != 0"
         }) }
-      it { is_expected.to contain_jboss__internal__interface__foreach("public:#{var}").with ({
+      it { is_expected.to contain_jboss__internal__interface__foreach("public:#{var}").with({
         :cfg_file => '/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml',
         :path     => 'server/interfaces'
         }) }
     end
-    it { is_expected.to contain_service('wildfly').with ({
+    it { is_expected.to contain_service('wildfly').with({
       :ensure => 'running',
       :enable => true
       }) }

--- a/spec/classes/internal/service_spec.rb
+++ b/spec/classes/internal/service_spec.rb
@@ -32,7 +32,7 @@ describe 'jboss::internal::service', :type => :define do
       it { is_expected.to contain_augeas("interface public rm #{var}") }
       it { is_expected.to contain_jboss__internal__interface__foreach("public:#{var}") }
     end
-    it { is_expected.to contain_service('wildfly').with ({
+    it { is_expected.to contain_service('wildfly').with({
       :ensure => 'running',
       :enable => true
       })}

--- a/spec/defines/clientry_spec.rb
+++ b/spec/defines/clientry_spec.rb
@@ -15,7 +15,7 @@ describe 'jboss::clientry', :type => :define do
 
   shared_examples 'completly working define' do
     it { is_expected.to compile }
-    it { is_expected.to contain_jboss_confignode(title).with ({
+    it { is_expected.to contain_jboss_confignode(title).with({
       :ensure => 'present',
       :path   => 'profile/test'
       }) }
@@ -29,25 +29,25 @@ describe 'jboss::clientry', :type => :define do
     it { is_expected.to contain_class 'jboss::internal::runtime::dc' }
     it { is_expected.to contain_class 'jboss::internal::configure::interfaces' }
     it { is_expected.to contain_jboss_confignode(title).that_requires('Anchor[jboss::package::end]') }
-    it { is_expected.to contain_jboss__clientry(title).with ({
+    it { is_expected.to contain_jboss__clientry(title).with({
       :ensure => 'present',
       :path   => 'profile/test',
       }) }
-    it { is_expected.to contain_jboss__interface('public').with ({
+    it { is_expected.to contain_jboss__interface('public').with({
       :ensure       => 'present',
       :inet_address => nil
       }) }
-    it { is_expected.to contain_augeas('ensure present interface public').with ({
+    it { is_expected.to contain_augeas('ensure present interface public').with({
         :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
         :changes => "set server/interfaces/interface[last()+1]/#attribute/name public",
         :onlyif  => "match server/interfaces/interface[#attribute/name='public'] size == 0"
         }) }
-    it { is_expected.to contain_augeas('interface public set any-address').with ({
+    it { is_expected.to contain_augeas('interface public set any-address').with({
       :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
       :changes => "set server/interfaces/interface[#attribute/name='public']/any-address/#attribute/value 'true'",
       :onlyif  => "get server/interfaces/interface[#attribute/name='public']/any-address/#attribute/value != 'true'"
       }) }
-    it { is_expected.to contain_jboss__internal__interface__foreach("public:any-address").with ({
+    it { is_expected.to contain_jboss__internal__interface__foreach("public:any-address").with({
       :cfg_file => '/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml',
       :path     => 'server/interfaces'
       }) }
@@ -57,17 +57,17 @@ describe 'jboss::clientry', :type => :define do
     end
 
     bind_variables_list.each do |var|
-      it { is_expected.to contain_augeas("interface public rm #{var}").with ({
+      it { is_expected.to contain_augeas("interface public rm #{var}").with({
         :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
         :changes => "rm server/interfaces/interface[#attribute/name='public']/#{var}",
         :onlyif  => "match server/interfaces/interface[#attribute/name='public']/#{var} size != 0"
         }) }
-      it { is_expected.to contain_jboss__internal__interface__foreach("public:#{var}").with ({
+      it { is_expected.to contain_jboss__internal__interface__foreach("public:#{var}").with({
         :cfg_file => '/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml',
         :path     => 'server/interfaces'
         }) }
     end
-    it { is_expected.to contain_service('wildfly').with ({
+    it { is_expected.to contain_service('wildfly').with({
       :ensure => 'running',
       :enable => true
       }) }

--- a/spec/defines/deploy_spec.rb
+++ b/spec/defines/deploy_spec.rb
@@ -15,12 +15,12 @@ describe 'jboss::deploy', :type => :define do
 
   shared_examples 'completly working define' do
     it { is_expected.to compile }
-    it { is_expected.to contain_jboss__deploy(title).with ({
+    it { is_expected.to contain_jboss__deploy(title).with({
       :ensure       => 'present',
       :path         => '/tmp/jboss.war',
       :servergroups => ''
       }) }
-    it { is_expected.to contain_jboss_deploy(title).with ({
+    it { is_expected.to contain_jboss_deploy(title).with({
       :ensure   => 'present',
       :source   => '/tmp/jboss.war',
       :redeploy => false
@@ -31,21 +31,21 @@ describe 'jboss::deploy', :type => :define do
     it { is_expected.to contain_group 'jboss' }
     it { is_expected.to contain_class 'jboss::params' }
     it {is_expected.to contain_class 'jboss::internal::runtime::node' }
-    it { is_expected.to contain_jboss__interface('public').with ({
+    it { is_expected.to contain_jboss__interface('public').with({
       :ensure       => 'present',
       :inet_address => nil
       }) }
-    it { is_expected.to contain_augeas('ensure present interface public').with ({
+    it { is_expected.to contain_augeas('ensure present interface public').with({
       :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
       :changes => "set server/interfaces/interface[last()+1]/#attribute/name public",
       :onlyif  => "match server/interfaces/interface[#attribute/name='public'] size == 0"
       }) }
-    it { is_expected.to contain_augeas('interface public set any-address').with ({
+    it { is_expected.to contain_augeas('interface public set any-address').with({
       :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
       :changes => "set server/interfaces/interface[#attribute/name='public']/any-address/#attribute/value 'true'",
       :onlyif  => "get server/interfaces/interface[#attribute/name='public']/any-address/#attribute/value != 'true'"
       }) }
-    it { is_expected.to contain_jboss__internal__interface__foreach("public:any-address").with ({
+    it { is_expected.to contain_jboss__internal__interface__foreach("public:any-address").with({
       :cfg_file => '/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml',
       :path     => 'server/interfaces'
       }) }
@@ -55,17 +55,17 @@ describe 'jboss::deploy', :type => :define do
     end
 
     bind_variables_list.each do |var|
-      it { is_expected.to contain_augeas("interface public rm #{var}").with ({
+      it { is_expected.to contain_augeas("interface public rm #{var}").with({
         :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
         :changes => "rm server/interfaces/interface[#attribute/name='public']/#{var}",
         :onlyif  => "match server/interfaces/interface[#attribute/name='public']/#{var} size != 0"
         }) }
-      it { is_expected.to contain_jboss__internal__interface__foreach("public:#{var}").with ({
+      it { is_expected.to contain_jboss__internal__interface__foreach("public:#{var}").with({
         :cfg_file => '/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml',
         :path     => 'server/interfaces'
         }) }
     end
-    it { is_expected.to contain_service('wildfly').with ({
+    it { is_expected.to contain_service('wildfly').with({
       :ensure => 'running',
       :enable => true
       }) }

--- a/spec/defines/jmsqueue_spec.rb
+++ b/spec/defines/jmsqueue_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper_puppet'
 describe 'jboss::jmsqueue', :type => :define do
   shared_examples 'completly working define' do
     it { is_expected.to compile }
-    it { is_expected.to contain_jboss_jmsqueue(title).with ({
+    it { is_expected.to contain_jboss_jmsqueue(title).with({
       :ensure  => 'present',
       :entries => [
       'queue/app-mails',

--- a/spec/defines/module_spec.rb
+++ b/spec/defines/module_spec.rb
@@ -19,21 +19,21 @@ describe 'jboss::module', :type => :define do
     it { is_expected.to contain_user 'jboss' }
     it { is_expected.to contain_group 'jboss' }
     it { is_expected.to contain_class 'jboss::params' }
-    it { is_expected.to contain_jboss__internal__module__assemble(title).with ({
+    it { is_expected.to contain_jboss__internal__module__assemble(title).with({
       :layer        => 'jdbc',
       :artifacts    => ["https://jdbc.postgresql.org/download/postgresql-9.4-1204.jdbc41.jar"],
       :dependencies => ["javax.transaction.api", "javax.api"]
     })}
 
-    it { is_expected.to contain_jboss__module(title).with ({
+    it { is_expected.to contain_jboss__module(title).with({
       :layer        => 'jdbc',
       :artifacts    => ["https://jdbc.postgresql.org/download/postgresql-9.4-1204.jdbc41.jar"]
       }) }
-    it { is_expected.to contain_jboss__interface('public').with ({
+    it { is_expected.to contain_jboss__interface('public').with({
       :ensure       => 'present',
       :inet_address => nil
       }) }
-    it { is_expected.to contain_augeas('ensure present interface public').with ({
+    it { is_expected.to contain_augeas('ensure present interface public').with({
       :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
       :changes => "set server/interfaces/interface[last()+1]/#attribute/name public",
       :onlyif  => "match server/interfaces/interface[#attribute/name='public'] size == 0"
@@ -42,23 +42,23 @@ describe 'jboss::module', :type => :define do
       it { is_expected.to contain_anchor("#{item}") }
     end
     bind_variables_list.each do |var|
-      it { is_expected.to contain_augeas("interface public rm #{var}").with ({
+      it { is_expected.to contain_augeas("interface public rm #{var}").with({
         :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
         :changes => "rm server/interfaces/interface[#attribute/name='public']/#{var}",
         :onlyif  => "match server/interfaces/interface[#attribute/name='public']/#{var} size != 0"
         }) }
-      it { is_expected.to contain_jboss__internal__interface__foreach("public:#{var}").with ({
+      it { is_expected.to contain_jboss__internal__interface__foreach("public:#{var}").with({
         :cfg_file => '/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml',
         :path     => 'server/interfaces'
         }) }
       end
 
-    it { is_expected.to contain_augeas('interface public set any-address').with ({
+    it { is_expected.to contain_augeas('interface public set any-address').with({
       :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
       :changes => "set server/interfaces/interface[#attribute/name='public']/any-address/#attribute/value 'true'",
       :onlyif  => "get server/interfaces/interface[#attribute/name='public']/any-address/#attribute/value != 'true'"
       }) }
-    it { is_expected.to contain_jboss__internal__interface__foreach("public:any-address").with ({
+    it { is_expected.to contain_jboss__internal__interface__foreach("public:any-address").with({
       :cfg_file => '/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml',
       :path     => 'server/interfaces'
       }) }

--- a/spec/defines/resourceadapter_spec.rb
+++ b/spec/defines/resourceadapter_spec.rb
@@ -15,7 +15,7 @@ describe 'jboss::resourceadapter', :type => :define do
 
   shared_examples 'completly working define' do
     it { is_expected.to compile }
-    it { is_expected.to contain_jboss_resourceadapter(title).with ({
+    it { is_expected.to contain_jboss_resourceadapter(title).with({
       :ensure  => 'present',
       :archive => 'jca-filestore.rar'
     })}
@@ -26,28 +26,28 @@ describe 'jboss::resourceadapter', :type => :define do
     it { is_expected.to contain_class 'jboss::params' }
     it { is_expected.to contain_class 'jboss::internal::service' }
     it { is_expected.to contain_class 'jboss::internal::runtime::node' }
-    it { is_expected.to contain_jboss__resourceadapter(title).with ({
+    it { is_expected.to contain_jboss__resourceadapter(title).with({
       :ensure             => 'present',
       :archive            => 'jca-filestore.rar',
       :transactionsupport => 'LocalTransaction',
       :classname          => 'org.example.jca.FileSystemConnectionFactory',
       }) }
 
-    it { is_expected.to contain_jboss__interface('public').with ({
+    it { is_expected.to contain_jboss__interface('public').with({
       :ensure       => 'present',
       :inet_address => nil
       }) }
-    it { is_expected.to contain_augeas('ensure present interface public').with ({
+    it { is_expected.to contain_augeas('ensure present interface public').with({
       :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
       :changes => "set server/interfaces/interface[last()+1]/#attribute/name public",
       :onlyif  => "match server/interfaces/interface[#attribute/name='public'] size == 0"
       }) }
-    it { is_expected.to contain_augeas('interface public set any-address').with ({
+    it { is_expected.to contain_augeas('interface public set any-address').with({
       :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
       :changes => "set server/interfaces/interface[#attribute/name='public']/any-address/#attribute/value 'true'",
       :onlyif  => "get server/interfaces/interface[#attribute/name='public']/any-address/#attribute/value != 'true'"
       }) }
-    it { is_expected.to contain_jboss__internal__interface__foreach("public:any-address").with ({
+    it { is_expected.to contain_jboss__internal__interface__foreach("public:any-address").with({
       :cfg_file => '/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml',
       :path     => 'server/interfaces'
       }) }
@@ -57,17 +57,17 @@ describe 'jboss::resourceadapter', :type => :define do
       end
 
     bind_variables_list.each do |var|
-      it { is_expected.to contain_augeas("interface public rm #{var}").with ({
+      it { is_expected.to contain_augeas("interface public rm #{var}").with({
         :context => '/files/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml/',
         :changes => "rm server/interfaces/interface[#attribute/name='public']/#{var}",
         :onlyif  => "match server/interfaces/interface[#attribute/name='public']/#{var} size != 0"
         }) }
-      it { is_expected.to contain_jboss__internal__interface__foreach("public:#{var}").with ({
+      it { is_expected.to contain_jboss__internal__interface__foreach("public:#{var}").with({
         :cfg_file => '/usr/lib/wildfly-8.2.0.Final/standalone/configuration/standalone-full.xml',
         :path     => 'server/interfaces'
         }) }
       end
-    it { is_expected.to contain_service('wildfly').with ({
+    it { is_expected.to contain_service('wildfly').with({
       :ensure => 'running',
       :enable => true
       }) }

--- a/spec/defines/securitydomain_spec.rb
+++ b/spec/defines/securitydomain_spec.rb
@@ -6,7 +6,7 @@ describe 'jboss::securitydomain', :type => :define do
     it { is_expected.to contain_class 'jboss' }
     it { is_expected.to contain_class 'jboss::internal::service' }
     it { is_expected.to contain_class 'jboss::internal::runtime::node' }
-    it { is_expected.to contain_jboss_securitydomain(title).with ({
+    it { is_expected.to contain_jboss_securitydomain(title).with({
       :ensure => 'present'
       }) }
     it { is_expected.to contain_jboss__securitydomain(title) }


### PR DESCRIPTION
Remove spaces before arguments to avoid warning message in Travis build on Ruby ver. 1.8

This minor bugfix for already megred PR #51 