### PR TITLE
Bugfix for issue #47 - idempotency issue while running on Docker container

### DIFF
--- a/lib/facter/jboss_virtual.rb
+++ b/lib/facter/jboss_virtual.rb
@@ -1,0 +1,8 @@
+Facter.add(:jboss_virtual) do
+  setcode do
+    virtual = Facter.value(:virtual)
+    ret = virtual
+    ret = 'docker' if virtual == 'physical' and Puppet_X::Coi::Jboss::Facts.dockerized?
+    ret
+  end
+end

--- a/lib/puppet_x/coi/jboss/facts.rb
+++ b/lib/puppet_x/coi/jboss/facts.rb
@@ -25,10 +25,10 @@ class Puppet_X::Coi::Jboss::Facts
         end
       end
 
-    # Check is dockerized
+    # Check if is running inside Docker container
     # Implementation is taken from Facter 2.1.x
-    # @deprecated TODO: remove afre droping support for Puppet 2.x
-    # @return {boolean} true is running inside container
+    # @deprecated TODO: remove after dropping support for Puppet 2.x
+    # @return {boolean} true if running inside container
     def dockerized?
       path = Pathname.new('/proc/1/cgroup')
       return false unless path.readable?

--- a/lib/puppet_x/coi/jboss/facts.rb
+++ b/lib/puppet_x/coi/jboss/facts.rb
@@ -24,5 +24,17 @@ class Puppet_X::Coi::Jboss::Facts
           end
         end
       end
+
+    # Check is dockerized
+    # Implementation is taken from Facter 2.1.x
+    # @deprecated TODO: remove afre droping support for Puppet 2.x
+    # @return {boolean} true is running inside container
+    def dockerized?
+      path = Pathname.new('/proc/1/cgroup')
+      return false unless path.readable?
+      in_docker = path.readlines.any? {|l| l.split(":")[2].to_s.start_with? '/docker/' }
+      return true if in_docker
+      return false
+    end
   end
 end

--- a/manifests/internal/service.pp
+++ b/manifests/internal/service.pp
@@ -13,10 +13,15 @@ class jboss::internal::service {
   anchor { 'jboss::service::begin': }
 
   $servicename = $jboss::product
+  # TODO: change to $::virtual after dropping support for Puppet 2.x
+  $enable = $::jboss_virtual ? {
+    'docker' => undef,
+    default  => true,
+  }
 
   service { $servicename:
     ensure     => running,
-    enable     => true,
+    enable     => $enable,
     hasstatus  => true,
     hasrestart => true,
     subscribe  => [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,15 +1,8 @@
 require 'spec_helper_puppet'
 
 describe 'jboss', :type => :class do
-  let(:facts) do
-    {
-      :operatingsystem => 'OracleLinux',
-      :osfamily        => 'RedHat',
-      :ipaddress       => '192.168.0.1',
-      :concat_basedir  => '/root/concat',
-      :puppetversion   => Puppet.version
-    }
-  end
+
+  let(:facts) { Testing::JBoss::SharedFacts.oraclelinux_facts }
   context 'with defaults for all parameters' do
     it { is_expected.to compile }
     it do

--- a/spec/classes/internal/augeas_spec.rb
+++ b/spec/classes/internal/augeas_spec.rb
@@ -11,15 +11,7 @@ describe 'jboss::internal::augeas', :type => :class do
   context 'On RedHat os family' do
     extend Testing::JBoss::SharedExamples
     let(:title) { 'test-augeas' }
-    let(:facts) do
-      {
-        :operatingsystem => 'OracleLinux',
-        :osfamily        => 'RedHat',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :puppetversion   => Puppet.version
-      }
-    end
+    let(:facts) { Testing::JBoss::SharedFacts.oraclelinux_facts }
     it_behaves_like 'completly working define'
     it_behaves_like_full_working_jboss_installation
 
@@ -28,16 +20,7 @@ describe 'jboss::internal::augeas', :type => :class do
   context 'On Debian os family' do
     extend Testing::JBoss::SharedExamples
     let(:title) { 'test-augeas' }
-    let(:facts) do
-      {
-        :operatingsystem => 'Ubuntu',
-        :osfamily        => 'Debian',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :lsbdistcodename => 'trusty',
-        :puppetversion   => Puppet.version
-      }
-    end
+    let(:facts) { Testing::JBoss::SharedFacts.ubuntu_facts }
     it_behaves_like 'completly working define'
     it_behaves_like_full_working_jboss_installation
 

--- a/spec/classes/internal/configuration_spec.rb
+++ b/spec/classes/internal/configuration_spec.rb
@@ -47,15 +47,7 @@ describe 'jboss::internal::configuration', :type => :class do
   context 'On RedHat os family' do
     extend Testing::JBoss::SharedExamples
     let(:title) { 'test-configuration' }
-    let(:facts) do
-      {
-        :operatingsystem => 'OracleLinux',
-        :osfamily        => 'RedHat',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :puppetversion   => Puppet.version
-      }
-    end
+    let(:facts) { Testing::JBoss::SharedFacts.oraclelinux_facts }
     it_behaves_like 'completly working define'
     it_behaves_like_full_working_jboss_installation
     it { is_expected.to contain_file('/etc/sysconfig/wildfly.conf') }
@@ -64,16 +56,7 @@ describe 'jboss::internal::configuration', :type => :class do
   context 'On Debian os family' do
     extend Testing::JBoss::SharedExamples
     let(:title) { 'test-configuration' }
-    let(:facts) do
-      {
-        :operatingsystem => 'Ubuntu',
-        :osfamily        => 'Debian',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :lsbdistcodename => 'trusty',
-        :puppetversion   => Puppet.version
-      }
-    end
+    let(:facts) { Testing::JBoss::SharedFacts.ubuntu_facts }
     it_behaves_like 'completly working define'
     it_behaves_like_full_working_jboss_installation
     it { is_expected.to contain_file('/etc/default/wildfly') }

--- a/spec/classes/internal/configure/interfaces_spec.rb
+++ b/spec/classes/internal/configure/interfaces_spec.rb
@@ -6,17 +6,9 @@ describe 'jboss::internal::configure::interfaces', :type => :define do
   end
 
   context 'On RedHat os family' do
-    let(:title) { 'test-conf-interfaces' }
     extend Testing::JBoss::SharedExamples
-    let(:facts) do
-      {
-        :operatingsystem => 'OracleLinux',
-        :osfamily        => 'RedHat',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :puppetversion   => Puppet.version
-      }
-    end
+    let(:title) { 'test-conf-interfaces' }
+    let(:facts) { Testing::JBoss::SharedFacts.oraclelinux_facts }
     it_behaves_like 'completly working define'
     it_behaves_like_full_working_jboss_installation
   end
@@ -24,16 +16,7 @@ describe 'jboss::internal::configure::interfaces', :type => :define do
   context 'On Debian os family' do
     extend Testing::JBoss::SharedExamples
     let(:title) { 'test-conf-interfaces' }
-    let(:facts) do
-      {
-        :operatingsystem => 'Ubuntu',
-        :osfamily        => 'Debian',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :lsbdistcodename => 'trusty',
-        :puppetversion   => Puppet.version
-      }
-    end
+    let(:facts) { Testing::JBoss::SharedFacts.ubuntu_facts }
     it_behaves_like 'completly working define'
     it_behaves_like_full_working_jboss_installation
   end

--- a/spec/classes/internal/lenses_spec.rb
+++ b/spec/classes/internal/lenses_spec.rb
@@ -22,30 +22,13 @@ describe 'jboss::internal::lenses', :type => :class do
 
   context 'On RedHat os family' do
     let(:title) { 'test-lenses' }
-    let(:facts) do
-      {
-        :operatingsystem => 'OracleLinux',
-        :osfamily        => 'RedHat',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :puppetversion   => Puppet.version
-      }
-    end
+    let(:facts) { Testing::JBoss::SharedFacts.oraclelinux_facts }
     it_behaves_like 'completly working define'
   end
 
   context 'On Debian os family' do
     let(:title) { 'test-lenses' }
-    let(:facts) do
-      {
-        :operatingsystem => 'Ubuntu',
-        :osfamily        => 'Debian',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :lsbdistcodename => 'trusty',
-        :puppetversion   => Puppet.version
-      }
-    end
+    let(:facts) { Testing::JBoss::SharedFacts.ubuntu_facts }
     it_behaves_like 'completly working define'
   end
 end

--- a/spec/classes/internal/prerequisites_spec.rb
+++ b/spec/classes/internal/prerequisites_spec.rb
@@ -9,29 +9,12 @@ describe 'jboss::internal::prerequisites', :type => :define do
 
   context 'On RedHat os family' do
     let(:title) { 'test-prerequisites' }
-    let(:facts) do
-      {
-        :operatingsystem => 'OracleLinux',
-        :osfamily        => 'RedHat',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :puppetversion   => Puppet.version
-      }
-    end
+    let(:facts) { Testing::JBoss::SharedFacts.oraclelinux_facts }
     it_behaves_like 'completly working define'
   end
   context 'On Debian os family' do
     let(:title) { 'test-module' }
-    let(:facts) do
-      {
-        :operatingsystem => 'Ubuntu',
-        :osfamily        => 'Debian',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :lsbdistcodename => 'trusty',
-        :puppetversion   => Puppet.version
-      }
-    end
+    let(:facts) { Testing::JBoss::SharedFacts.ubuntu_facts }
     it_behaves_like 'completly working define'
   end
 end

--- a/spec/classes/internal/quirks/etc_initd_functions_spec.rb
+++ b/spec/classes/internal/quirks/etc_initd_functions_spec.rb
@@ -8,15 +8,7 @@ describe 'jboss::internal::quirks::etc_initd_functions', :type => :define do
   context 'On RedHat os family' do
     extend Testing::JBoss::SharedExamples
     let(:title) { 'test-etc_initd_functions' }
-    let(:facts) do
-      {
-        :operatingsystem => 'OracleLinux',
-        :osfamily        => 'RedHat',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :puppetversion   => Puppet.version
-      }
-    end
+    let(:facts) { Testing::JBoss::SharedFacts.oraclelinux_facts }
     it_behaves_like 'completly working define'
     it_behaves_like_full_working_jboss_installation
 
@@ -25,16 +17,7 @@ describe 'jboss::internal::quirks::etc_initd_functions', :type => :define do
   context 'On Debian os family' do
     extend Testing::JBoss::SharedExamples
     let(:title) { 'test-etc_initd_functions' }
-    let(:facts) do
-      {
-        :operatingsystem => 'Ubuntu',
-        :osfamily        => 'Debian',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :lsbdistcodename => 'trusty',
-        :puppetversion   => Puppet.version
-      }
-    end
+    let(:facts) { Testing::JBoss::SharedFacts.ubuntu_facts }
     it_behaves_like 'completly working define'
     it_behaves_like_full_working_jboss_installation
 

--- a/spec/classes/internal/service_spec.rb
+++ b/spec/classes/internal/service_spec.rb
@@ -1,41 +1,107 @@
 require 'spec_helper_puppet'
 
-describe 'jboss::internal::service', :type => :define do
-  shared_examples 'completly working define' do
+describe 'jboss::internal::service', :type => :class do
+  shared_examples 'containg service anchors' do
+    it { is_expected.to contain_anchor('jboss::service::begin') }
+    it { is_expected.to contain_anchor('jboss::service::end') }
+    it { is_expected.to contain_anchor('jboss::service::started') }
+  end
+  shared_examples 'containg class structure' do
     it { is_expected.to contain_class 'jboss::internal::service' }
-    it { is_expected.to contain_exec('jboss::move-unzipped') }
+    it { is_expected.to contain_class('jboss') }
+    it { is_expected.to contain_class('jboss::params') }
+    it { is_expected.to contain_class('jboss::internal::configuration') }
+  end
+  shared_examples 'containg service execs' do
+    it do
+      is_expected.to contain_exec('jboss::service::test-running').
+      with(
+        :loglevel  => 'emerg',
+        :command   => 'tail -n 50 /var/log/wildfly/console.log && exit 1',
+        :unless    => 'ps aux | grep wildfly | grep -vq grep',
+        :logoutput => true
+      )
+    end
+    it do
+      is_expected.to contain_exec('jboss::service::restart').
+      with(
+        :command     => 'service wildfly stop ; pkill -9 -f "^java.*jboss"  ; service wildfly start',
+        :refreshonly => true
+      )
+    end
   end
 
-  context 'On RedHat os family' do
-    extend Testing::JBoss::SharedExamples
-    let(:title) { 'test-service' }
-    let(:facts) do
-      {
-        :operatingsystem => 'OracleLinux',
-        :osfamily        => 'RedHat',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :puppetversion   => Puppet.version
-      }
+  context 'on RedHat os family' do
+    context 'on Docker container' do
+      let(:facts) do
+        Testing::JBoss::SharedFacts.oraclelinux_facts(
+          :jboss_virtual => 'docker'
+        )
+      end
+      it_behaves_like 'containg service anchors'
+      it_behaves_like 'containg service execs'
+      it_behaves_like 'containg class structure'
+      it { is_expected.to contain_service('wildfly').
+        with(
+          :ensure     => 'running',
+          :enable     => nil,
+          :hasstatus  => true,
+          :hasrestart => true
+        ) }
     end
-    it_behaves_like 'completly working define'
-    it_behaves_like_full_working_jboss_installation
+    context 'on non-Docker machine' do
+      let(:facts) do
+        Testing::JBoss::SharedFacts.oraclelinux_facts(
+          :jboss_virtual => 'phisycal'
+        )
+      end
+      it_behaves_like 'containg service anchors'
+      it_behaves_like 'containg service execs'
+      it_behaves_like 'containg class structure'
+      it { is_expected.to contain_service('wildfly').
+        with(
+          :ensure     => 'running',
+          :enable     => true,
+          :hasstatus  => true,
+          :hasrestart => true
+        ) }
+    end
   end
 
-  context 'On Debian os family' do
-    extend Testing::JBoss::SharedExamples
-    let(:title) { 'test-module' }
-    let(:facts) do
-      {
-        :operatingsystem => 'Ubuntu',
-        :osfamily        => 'Debian',
-        :ipaddress       => '192.168.0.1',
-        :concat_basedir  => '/root/concat',
-        :lsbdistcodename => 'trusty',
-        :puppetversion   => Puppet.version
-      }
+  context 'on Debian os family' do
+    context 'on Docker container' do
+      let(:facts) do
+        Testing::JBoss::SharedFacts.ubuntu_facts(
+          :jboss_virtual => 'docker'
+        )
+      end
+      it_behaves_like 'containg service anchors'
+      it_behaves_like 'containg service execs'
+      it_behaves_like 'containg class structure'
+      it { is_expected.to contain_service('wildfly').
+        with(
+          :ensure     => 'running',
+          :enable     => nil,
+          :hasstatus  => true,
+          :hasrestart => true
+        ) }
     end
-    it_behaves_like 'completly working define'
-    it_behaves_like_full_working_jboss_installation
+    context 'on non-Docker machine' do
+      let(:facts) do
+        Testing::JBoss::SharedFacts.ubuntu_facts(
+          :jboss_virtual => 'vmware'
+        )
+      end
+      it_behaves_like 'containg service anchors'
+      it_behaves_like 'containg service execs'
+      it_behaves_like 'containg class structure'
+      it { is_expected.to contain_service('wildfly').
+        with(
+          :ensure     => 'running',
+          :enable     => true,
+          :hasstatus  => true,
+          :hasrestart => true
+        ) }
+    end
   end
 end

--- a/spec/spec_helper_puppet.rb
+++ b/spec/spec_helper_puppet.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 module Testing
   module JBoss end
 end
+require 'testing/jboss/shared_facts'
 require 'testing/jboss/shared_examples'
 
 at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/testing/jboss/shared_facts.rb
+++ b/spec/testing/jboss/shared_facts.rb
@@ -1,0 +1,38 @@
+class Testing::JBoss::SharedFacts
+  DEFAULT_IP         = '192.168.0.1'
+  DEFAULT_CONCAT_DIR = '/root/concat'
+
+  DEFAULT_ORACLELINUX_FACTS = {
+    :operatingsystem           => 'OracleLinux',
+    :osfamily                  => 'RedHat',
+    :ipaddress                 => DEFAULT_IP,
+    :concat_basedir            => DEFAULT_CONCAT_DIR,
+    :operatingsystemrelease    => '6.7',
+    :operatingsystemmajrelease => '6',
+    :puppetversion             => Puppet.version.to_s
+  }
+  DEFAULT_UBUNTU_RELEASE = '14.04'
+  DEFAULT_UBUNTU_FACTS = {
+    :operatingsystem           => 'Ubuntu',
+    :osfamily                  => 'Debian',
+    :ipaddress                 => DEFAULT_IP,
+    :concat_basedir            => DEFAULT_CONCAT_DIR,
+    :operatingsystemmajrelease => DEFAULT_UBUNTU_RELEASE,
+    :operatingsystemrelease    => DEFAULT_UBUNTU_RELEASE,
+    :lsbdistcodename           => 'trusty',
+    :lsbdistdescription        => 'Ubuntu 14.04.3 LTS',
+    :lsbdistid                 => 'Ubuntu',
+    :lsbdistrelease            => DEFAULT_UBUNTU_RELEASE,
+    :lsbmajdistrelease         => DEFAULT_UBUNTU_RELEASE,
+    :puppetversion             => Puppet.version.to_s
+  }
+  class << self
+    def ubuntu_facts(override = {})
+      DEFAULT_UBUNTU_FACTS.merge(override)
+    end
+
+    def oraclelinux_facts(override = {})
+      DEFAULT_ORACLELINUX_FACTS.merge(override)
+    end
+  end
+end

--- a/spec/unit/facter/jboss_virtual_spec.rb
+++ b/spec/unit/facter/jboss_virtual_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'jboss_virtual', :type => :fact do
+  let(:lines) do
+    lines = <<-EOS
+    11:name=systemd:/
+    10:hugetlb:/docker/715a4a76b43c6d67a4900f2cd3f718191671c19b09699c0a16a4fbc48bc69004
+    9:perf_event:/docker/715a4a76b43c6d67a4900f2cd3f718191671c19b09699c0a16a4fbc48bc69004
+    8:blkio:/docker/715a4a76b43c6d67a4900f2cd3f718191671c19b09699c0a16a4fbc48bc69004
+    7:freezer:/docker/715a4a76b43c6d67a4900f2cd3f718191671c19b09699c0a16a4fbc48bc69004
+    6:devices:/docker/715a4a76b43c6d67a4900f2cd3f718191671c19b09699c0a16a4fbc48bc69004
+    5:memory:/docker/715a4a76b43c6d67a4900f2cd3f718191671c19b09699c0a16a4fbc48bc69004
+    4:cpuacct:/docker/715a4a76b43c6d67a4900f2cd3f718191671c19b09699c0a16a4fbc48bc69004
+    3:cpu:/docker/715a4a76b43c6d67a4900f2cd3f718191671c19b09699c0a16a4fbc48bc69004
+    2:cpuset:/docker/715a4a76b43c6d67a4900f2cd3f718191671c19b09699c0a16a4fbc48bc69004
+    EOS
+    lines.split(/\n/)
+  end
+  let(:docker_pathname) { double(:readable? => true, :readlines => lines) }
+  let(:nondocker_pathname) { double(:readable? => true, :readlines => []) }
+  before(:each) do
+    allow(Facter).to receive(:value).with(:jboss_virtual).and_call_original
+    allow(Facter).to receive(:value).with(:virtual).and_return('physical')
+  end
+  after :each do
+    fct = Facter.fact :jboss_virtual
+    fct.instance_variable_set(:@value, nil)
+  end
+  subject { Facter.value(:jboss_virtual) }
+  context 'on Docker container' do
+    before(:each) do
+      allow(Pathname).to receive(:new).and_call_original
+      allow(Pathname).to receive(:new).with('/proc/1/cgroup').and_return(docker_pathname)
+    end
+    it { expect { subject }.not_to raise_error }
+    it { expect(subject).to eq('docker') }
+  end
+  context 'on non-Docker machine' do
+    before(:each) do
+      allow(Pathname).to receive(:new).and_call_original
+      allow(Pathname).to receive(:new).with('/proc/1/cgroup').and_return(nondocker_pathname)
+    end
+    it { expect { subject }.not_to raise_error }
+    it { expect(subject).to eq('physical') }
+  end
+end


### PR DESCRIPTION
This bugfix should solve the issue #47.

It utilize the new (deprecated from start) wrapper fact of `$::jboss_virtual` which adds support for Docker even before Facter 2.1.x.

Code in `service.pp` manifest should use standard `$::virtual` fact after dropping support for Puppet 2.x