### PR TITLE
Switch to Gitter.im chat instead of Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### ...with configuration management of resources and deployment in domain and stand-alone modes
 
-[![Build Status](https://travis-ci.org/coi-gov-pl/puppet-jboss.svg?branch=develop)](https://travis-ci.org/coi-gov-pl/puppet-jboss) [![Puppet Forge](https://img.shields.io/puppetforge/v/coi/jboss.svg)](https://forge.puppetlabs.com/coi/jboss) [![Code Climate](https://codeclimate.com/github/coi-gov-pl/puppet-jboss/badges/gpa.svg)](https://codeclimate.com/github/coi-gov-pl/puppet-jboss) [![Dependency Status](https://gemnasium.com/coi-gov-pl/puppet-jboss.svg)](https://gemnasium.com/coi-gov-pl/puppet-jboss) [![Coverage Status](https://coveralls.io/repos/coi-gov-pl/puppet-jboss/badge.svg?branch=develop&service=github)](https://coveralls.io/github/coi-gov-pl/puppet-jboss?branch=develop) [![Inline docs](http://inch-ci.org/github/coi-gov-pl/puppet-jboss.svg?branch=develop)](http://inch-ci.org/github/coi-gov-pl/puppet-jboss)
+[![Build Status](https://travis-ci.org/coi-gov-pl/puppet-jboss.svg?branch=develop)](https://travis-ci.org/coi-gov-pl/puppet-jboss) [![Puppet Forge](https://img.shields.io/puppetforge/v/coi/jboss.svg)](https://forge.puppetlabs.com/coi/jboss) [![Code Climate](https://codeclimate.com/github/coi-gov-pl/puppet-jboss/badges/gpa.svg)](https://codeclimate.com/github/coi-gov-pl/puppet-jboss) [![Dependency Status](https://gemnasium.com/coi-gov-pl/puppet-jboss.svg)](https://gemnasium.com/coi-gov-pl/puppet-jboss) [![Coverage Status](https://coveralls.io/repos/coi-gov-pl/puppet-jboss/badge.svg?branch=develop&service=github)](https://coveralls.io/github/coi-gov-pl/puppet-jboss?branch=develop) [![Inline docs](http://inch-ci.org/github/coi-gov-pl/puppet-jboss.svg?branch=develop)](http://inch-ci.org/github/coi-gov-pl/puppet-jboss) [![Join the chat at https://gitter.im/coi-gov-pl/puppet-jboss](https://badges.gitter.im/coi-gov-pl/puppet-jboss.svg)](https://gitter.im/coi-gov-pl/puppet-jboss?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 #### Table of Contents
 
@@ -44,7 +44,7 @@ In addition to the above list, you can also configure any JBoss CLI reachable co
 
 ### Got questions?
 
-We will be happy to receive your feedback. Ask as about everything releated to this module on [Slack](https://puppet-jboss.slack.com)!
+We will be happy to receive your feedback. Ask as about everything releated to this module on [Gitter.im chat](https://gitter.im/coi-gov-pl/puppet-jboss?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)!
 
 ## Setup
 


### PR DESCRIPTION
### coi-gov-pl/puppet-jboss now has a Chat Room on Gitter

@cardil has just created a chat room. You can visit it here: [https://gitter.im/coi-gov-pl/puppet-jboss](https://gitter.im/coi-gov-pl/puppet-jboss?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&content=body_link).

This pull-request adds this badge to your README.md:

[![Gitter](https://badges.gitter.im/coi-gov-pl/puppet-jboss.svg)](https://gitter.im/coi-gov-pl/puppet-jboss?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badge)

Gitter do not require user approval and user can sign in with Github accounts.